### PR TITLE
Update estlint config

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ramseyinhouse/eslint-config",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Ramsey Solutions",
   "description": "Ramsey Solutions standard ESLint configuration.",
   "main": "index.js",

--- a/packages/eslint-config/rules.js
+++ b/packages/eslint-config/rules.js
@@ -221,7 +221,6 @@ module.exports = {
     'object-shorthand': 0, // http://eslint.org/docs/rules/object-shorthand
     'prefer-arrow-callback': 2, // http://eslint.org/docs/rules/prefer-arrow-callback
     'prefer-const': 0, // http://eslint.org/docs/rules/prefer-const
-    'prefer-reflect': 2, // http://eslint.org/docs/rules/prefer-reflect
     'prefer-spread': 2, // http://eslint.org/docs/rules/prefer-spread
     'prefer-template': 2, // http://eslint.org/docs/rules/prefer-template
     'require-yield': 2, // http://eslint.org/docs/rules/require-yield


### PR DESCRIPTION
## Description of Proposed Changes
The `prefer-reflect` rule [was removed](https://github.com/lampo/ramsey-boilerplate/commit/39a6ed6244d5e507e2dae1a950f371b6cc7db6df) in our old Ramsey Boilerplate config. This PR makes the same change here. 

## Related Issue (if applicable)
https://github.com/lampo/ramsey-boilerplate/commit/39a6ed6244d5e507e2dae1a950f371b6cc7db6df

## Testing Steps
* ESLint should no longer care if you use `apply` or `call`: https://eslint.org/docs/rules/prefer-reflect